### PR TITLE
auth now in axios and axios pull at login/register

### DIFF
--- a/back-end/routes/users.js
+++ b/back-end/routes/users.js
@@ -20,7 +20,9 @@ router.get('/', function(req, res, next) {
 });
 
 //Friends
-router.get('/friends',(req,res,next)=>{ //Challenge: Inner Join a table twice
+router.post('/friends',(req,res,next)=>{ //Challenge: Inner Join a table twice
+  console.log("friends Route:")
+  console.log(req.body.auth)
   const friendsQuery = `SELECT u2.userName, u2.id, friendships.friendSince, friendships.exchanges, u2.avatarUrl
     FROM friendships
     INNER JOIN users u1 ON friendships.u1id = u1.id
@@ -35,7 +37,9 @@ router.get('/friends',(req,res,next)=>{ //Challenge: Inner Join a table twice
 });
 
 //Collection
-router.get('/collection',(req,res,next)=>{
+router.post('/collection',(req,res,next)=>{
+  console.log("collection Route:")
+  console.log(req.body.auth)
   // pull all records from the records table where 
   // (the uid in the collections table = the current user), 
   // (the crid of those items = rid in collection-records table)
@@ -63,8 +67,6 @@ router.get('/collection',(req,res,next)=>{
   // const userIdQuery = `SELECT id FROM users WHERE email = the current users email`
 
   // const collectionQuery = `SELECT * FROM records INNER JOIN`
-
-  console.log("collection route has been hit")
 
   connection.query(collectionQuery,(error,results)=>{
     // console.log(results)
@@ -255,10 +257,12 @@ router.post('/profileAvatar',upload.single('avatar'),(req,res,next)=>{
 });
 
 router.post('/community', (req,res,next)=>{
+  console.log("community Route:")
+  console.log(req.body.auth)
   // set variables for any locals i need
   // set a variable for my query
   // connection.query to run the query
-  console.log(req.body.auth)
+  
 
   
   // const currentUserId = `SELECT id FROM users WHERE token != ${req}`

--- a/front-end/src/actions/collectionAction.js
+++ b/front-end/src/actions/collectionAction.js
@@ -1,9 +1,12 @@
 import axios from 'axios';
 
-export default ()=>{
+export default (auth)=>{
     const axiosPromise = axios({
         url: `${window.apiHost}/users/collection`,
-        method: 'GET',
+        method: 'POST',
+        data: {
+            auth
+        }
     })
     return{
         type: "COLLECTION_ACTION",

--- a/front-end/src/actions/friendsAction.js
+++ b/front-end/src/actions/friendsAction.js
@@ -1,9 +1,12 @@
 import axios from 'axios';
 
-export default ()=>{
+export default (auth)=>{
     const axiosPromise = axios({
         url: `${window.apiHost}/users/friends`,
-        method: 'GET',
+        method: 'POST',
+        data: {
+            auth
+        }
     })
     return{
         type: "GET_FRIENDS_ACTION",

--- a/front-end/src/components/pages/Collection.js
+++ b/front-end/src/components/pages/Collection.js
@@ -19,7 +19,7 @@ class Collection extends Component{
     }
 
     componentDidMount(){
-        this.props.collectionAction();
+        // this.props.collectionAction();
 
         this.setState({
             footer:window.document.getElementById('footer'),
@@ -94,10 +94,10 @@ function mapStateToProps(state){
     }
 }
 
-function mapDispatchToProps(dispatcher){
-    return bindActionCreators({
-        collectionAction
-    },dispatcher)
-}
+// function mapDispatchToProps(dispatcher){
+//     return bindActionCreators({
+//         collectionAction
+//     },dispatcher)
+// }
 
-export default connect(mapStateToProps,mapDispatchToProps)(Collection);
+export default connect(mapStateToProps)(Collection);

--- a/front-end/src/components/pages/Friends.js
+++ b/front-end/src/components/pages/Friends.js
@@ -15,7 +15,7 @@ class Friends extends Component{
     }
 
     componentDidMount(){ //Challenge: Footer resize
-        this.props.friendsAction();
+        // this.props.friendsAction();
 
         this.setState({
             footer:window.document.getElementById('footer'),
@@ -89,10 +89,10 @@ function mapStateToProps(state){
     }
 }
 
-function mapDispatchToProps(dispatcher){
-    return bindActionCreators({
-        friendsAction
-    },dispatcher)
-}
+// function mapDispatchToProps(dispatcher){
+//     return bindActionCreators({
+//         friendsAction
+//     },dispatcher)
+// }
 
-export default connect(mapStateToProps,mapDispatchToProps)(Friends);
+export default connect(mapStateToProps)(Friends);

--- a/front-end/src/components/pages/Login.js
+++ b/front-end/src/components/pages/Login.js
@@ -4,6 +4,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import loginAction from '../../actions/loginAction';
 import communityAction from '../../actions/communityAction';
+import collectionAction from '../../actions/collectionAction';
+import friendsAction from '../../actions/friendsAction';
 import SweetAlert from 'sweetalert-react';
 import 'sweetalert/dist/sweetalert.css';
 import './form.css';
@@ -34,6 +36,8 @@ class Login extends Component{
         }else if(newProps.auth.msg === "Login Success"){
             console.log(newProps.auth)
             this.props.communityAction(newProps.auth);
+            this.props.collectionAction(newProps.auth);
+            this.props.friendsAction(newProps.auth);
             this.props.history.push('/users/userHome');
         }
     }
@@ -113,7 +117,9 @@ function MapStateToProps(state){
 function MapDispatchToProps(dispatcher){
     return bindActionCreators({
         loginAction,
-        communityAction
+        communityAction,
+        collectionAction,
+        friendsAction
     }, dispatcher)
 }
 

--- a/front-end/src/components/pages/Register.js
+++ b/front-end/src/components/pages/Register.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import authAction from '../../actions/authAction';
 import communityAction from '../../actions/communityAction';
+import collectionAction from '../../actions/collectionAction';
+import friendsAction from '../../actions/friendsAction';
 import { connect } from 'react-redux';
 import SweetAlert from 'sweetalert-react';
 import 'sweetalert/dist/sweetalert.css';
@@ -24,7 +26,9 @@ class Register extends Component{
                 showAlert: true
             })
         }else if(newProps.auth.msg === 'User Added'){ 
-            this.props.communityAction();
+            this.props.communityAction(newProps.auth);
+            this.props.collectionAction(newProps.auth);
+            this.props.friendsAction(newProps.auth);
             this.props.history.push('/users/profile');
         }
     }
@@ -114,7 +118,9 @@ function mapStateToProps(state){
 function mapDispatchToProps(dispatcher){
     return bindActionCreators({
         authAction: authAction,
-        communityAction
+        communityAction,
+        collectionAction,
+        friendsAction
     },dispatcher)
 }
 

--- a/front-end/src/components/userHomeCards/HomeCollection.js
+++ b/front-end/src/components/userHomeCards/HomeCollection.js
@@ -12,9 +12,9 @@ class HomeCollection extends Component{
         super()
     }
 
-    componentDidMount(){
-        this.props.collectionAction();
-    }
+    // componentDidMount(){
+    //     this.props.collectionAction();
+    // }
 
     render(){
         // console.log(this.props.coll[0].name)
@@ -81,13 +81,13 @@ function mapStateToProps(state){
     }
 }
 
-function mapDispatchToProps(dispatcher){
-    return bindActionCreators({
-        collectionAction
-    },dispatcher)
-}
+// function mapDispatchToProps(dispatcher){
+//     return bindActionCreators({
+//         collectionAction
+//     },dispatcher)
+// }
 
-export default connect(mapStateToProps,mapDispatchToProps)(HomeCollection);
+export default connect(mapStateToProps)(HomeCollection);
 
 
 

--- a/front-end/src/components/userHomeCards/HomeFriends.js
+++ b/front-end/src/components/userHomeCards/HomeFriends.js
@@ -10,9 +10,9 @@ class HomeFriends extends Component{
         super()
     }
 
-    componentDidMount(){
-        this.props.friendsAction();
-    }
+    // componentDidMount(){
+    //     this.props.friendsAction();
+    // }
 
     render(){
         console.log(this.props)
@@ -55,10 +55,10 @@ function mapStateToProps(state){
     }
 }
 
-function mapDispatchToProps(dispatcher){
-    return bindActionCreators({
-        friendsAction
-    },dispatcher)
-}
+// function mapDispatchToProps(dispatcher){
+//     return bindActionCreators({
+//         friendsAction
+//     },dispatcher)
+// }
 
-export default connect(mapStateToProps,mapDispatchToProps)(HomeFriends);
+export default connect(mapStateToProps)(HomeFriends);


### PR DESCRIPTION
I changed the friends, collections, and community axios requests to POST requests on the front end and back end and passed along the auth piece of state as data so that the back end now knows who is logged in and we can reference req.body.auth in our SQL queries. I also moved all three of these actions to the login and register components and removed them from the other components so now when you login/register it pulls all your users data in three axios requests and doesn't need to go to the back end again later on.